### PR TITLE
When available use name attribute for hosts as populated on rancher

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -3,9 +3,10 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/infinityworks/prometheus-rancher-exporter/measure"
 	"github.com/prometheus/client_golang/prometheus"
@@ -55,8 +56,11 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 		log.Debug("Processing metrics for %s", endpoint)
 
 		if endpoint == "hosts" {
-
-			if err := e.setHostMetrics(x.HostName, x.State, x.AgentState); err != nil {
+			var s = x.HostName
+			if x.Name != "" {
+				s = x.Name
+			}
+			if err := e.setHostMetrics(s, x.State, x.AgentState); err != nil {
 				log.Errorf("Error processing host metrics: %s", err)
 				log.Errorf("Attempt Failed to set %s, %s, [agent] %s ", x.HostName, x.State, x.AgentState)
 


### PR DESCRIPTION
If the name for a host has been populated manually use it instead of the hostname attribute. 
This avoids the ugly naming created by automated provisioning tools and the like.