### PR TITLE
Adds the "disconnected" state for the host states

### DIFF
--- a/rancher_exporter.go
+++ b/rancher_exporter.go
@@ -31,7 +31,7 @@ var (
 // Predefined variables that are used throughout the exporter
 var (
 	agentStates   = []string{"activating", "active", "reconnecting", "disconnected", "disconnecting", "finishing-reconnect", "reconnected"}
-	hostStates    = []string{"activating", "active", "deactivating", "error", "erroring", "inactive", "provisioned", "purged", "purging", "registering", "removed", "removing", "requested", "restoring", "updating_active", "updating_inactive"}
+	hostStates    = []string{"activating", "active", "deactivating", "disconnected", "error", "erroring", "inactive", "provisioned", "purged", "purging", "registering", "removed", "removing", "requested", "restoring", "updating_active", "updating_inactive"}
 	stackStates   = []string{"activating", "active", "canceled_upgrade", "canceling_upgrade", "error", "erroring", "finishing_upgrade", "removed", "removing", "requested", "restarting", "rolling_back", "updating_active", "upgraded", "upgrading"}
 	serviceStates = []string{"activating", "active", "canceled_upgrade", "canceling_upgrade", "deactivating", "finishing_upgrade", "inactive", "registering", "removed", "removing", "requested", "restarting", "rolling_back", "updating_active", "updating_inactive", "upgraded", "upgrading"}
 	healthStates  = []string{"healthy", "unhealthy", "initializing", "degraded"}


### PR DESCRIPTION
In order to know when a Rancher host is disconnected, we can add a missing state "disconnected". This state is available in Rancher, see an extract of the Rancher API:

```
},
"actions": {
"upgrade": "…/v2-beta/projects/1a361/hosts/1h19/?action=upgrade",
"evacuate": "…/v2-beta/projects/1a361/hosts/1h19/?action=evacuate",
"dockersocket": "…/v2-beta/projects/1a361/hosts/1h19/?action=dockersocket",
"update": "…/v2-beta/projects/1a361/hosts/1h19/?action=update",
"delete": "…/v2-beta/projects/1a361/hosts/1h19/?action=delete",
"deactivate": "…/v2-beta/projects/1a361/hosts/1h19/?action=deactivate"
},
"baseType": "host",
"name": null,
"state": "disconnected",
"accountId": "1a361",
"agentIpAddress": "34.242.136.5",
"agentState": "disconnected",
"amazonec2Config": null,
"authCertificateAuthority": null,
"authKey": null,
```
