### PR TITLE
Now, we can retrieve the correct state of the hosts

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -172,7 +172,8 @@ func setEndpoint(rancherURL string, component string, apiVer string) string {
 	if strings.Contains(component, "services") {
 		endpoint = (rancherURL + "/services/")
 	} else if strings.Contains(component, "hosts") {
-		endpoint = (rancherURL + "/hosts/")
+	    endpoint = (rancherURL + "/hosts/")
+        endpoint = strings.Replace(endpoint, "v1", "v2-beta", 1)
 	} else if strings.Contains(component, "stacks") {
 
 		if apiVer == "v1" {

--- a/rancher_exporter.go
+++ b/rancher_exporter.go
@@ -31,7 +31,7 @@ var (
 // Predefined variables that are used throughout the exporter
 var (
 	agentStates   = []string{"activating", "active", "reconnecting", "disconnected", "disconnecting", "finishing-reconnect", "reconnected"}
-	hostStates    = []string{"activating", "active", "deactivating", "disconnected", "error", "erroring", "inactive", "provisioned", "purged", "purging", "registering", "removed", "removing", "requested", "restoring", "updating_active", "updating_inactive"}
+	hostStates    = []string{"activating", "active", "deactivating", "disconnected", "error", "erroring", "inactive", "provisioned", "purged", "purging", "reconnecting", "registering", "removed", "removing", "requested", "restoring", "updating_active", "updating_inactive"}
 	stackStates   = []string{"activating", "active", "canceled_upgrade", "canceling_upgrade", "error", "erroring", "finishing_upgrade", "removed", "removing", "requested", "restarting", "rolling_back", "updating_active", "upgraded", "upgrading"}
 	serviceStates = []string{"activating", "active", "canceled_upgrade", "canceling_upgrade", "deactivating", "finishing_upgrade", "inactive", "registering", "removed", "removing", "requested", "restarting", "rolling_back", "updating_active", "updating_inactive", "upgraded", "upgrading"}
 	healthStates  = []string{"healthy", "unhealthy", "initializing", "degraded"}


### PR DESCRIPTION
Hi,
the v1 API doesn't provide the correct state for a host. If the state is 'reconnecting' or 'disconnected', the v1 API returns always 'active'. In the v2-beta API, the state is correctly returned.

`v1`
![image](https://user-images.githubusercontent.com/24875183/35869330-152911ca-0b5f-11e8-864d-2cbfdfac882e.png)

`v2-beta`
![image](https://user-images.githubusercontent.com/24875183/35869297-041771ce-0b5f-11e8-98ac-f5268450d2e3.png)



I propose to use the v2-beta instead of v1 when the exporter wants to retrieve information about the hosts. I have tested and it works fine.