### PR TITLE
Return error when key or secret for Rancher API is wrong.

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -142,6 +142,10 @@ func getJSON(url string, accessKey string, secretKey string, target interface{})
 		log.Error("Error Collecting JSON from API: ", err)
 	}
 
+	if resp.StatusCode != 200 {
+		log.Error("Error Collecting JSON from API: ", resp.Status)
+	}
+
 	respFormatted := json.NewDecoder(resp.Body).Decode(target)
 
 	// Timings recorded as part of internal metrics
@@ -161,7 +165,7 @@ func setEndpoint(rancherURL string, component string) string {
 	var endpoint string
 
 	endpoint = (rancherURL + "/" + component + "/")
-    endpoint = strings.Replace(endpoint, "v1", "v2-beta", 1)
+	endpoint = strings.Replace(endpoint, "v1", "v2-beta", 1)
 
 	return endpoint
 }


### PR DESCRIPTION
When key or secret are wrong we need to return error, otherwise it's hard to see whenever there is an issue with the exporter or not as it's still printing some default metrics.