### PR TITLE
add the API HTTP return code check to assist debugging

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -142,7 +142,7 @@ func getJSON(url string, accessKey string, secretKey string, target interface{})
 		log.Error("Error Collecting JSON from API: ", err)
 	}
 
-	if resp.Status != "200" {
+	if ! strings.Contains(resp.Status, "200") {
 		log.Error("Error returned from API: ",resp.Status) 	
 	}	
 	

--- a/gather.go
+++ b/gather.go
@@ -142,6 +142,10 @@ func getJSON(url string, accessKey string, secretKey string, target interface{})
 		log.Error("Error Collecting JSON from API: ", err)
 	}
 
+	if resp.Status != "200" {
+		log.Error("Error returned from API: ",resp.Status) 	
+	}	
+	
 	respFormatted := json.NewDecoder(resp.Body).Decode(target)
 
 	// Timings recorded as part of internal metrics


### PR DESCRIPTION
I added a simple check to print an error message if the API returns an http code different from 200.
The most common case will be the API returned "401 Unauthorized", in this case no Rancher metrics will be collected since this exporter just receives 'null' for every metrics.