### PR TITLE
Support host and service labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+exporter

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ If you are using this externally to Rancher, or without the use of the labels to
 * `METRICS_PATH`        // Path under which to expose metrics.
 * `LISTEN_ADDRESS`      // Port on which to expose metrics.
 * `HIDE_SYS`            // If set to `true` then this hides any of Ranchers internal system services from being shown. *If used, ensure `false` is encapsulated with quotes e.g. `HIDE_SYS="false"`.
-* `LABELS_FILTER`       // Regular expression for filtering service and host labels, defaults to `.*`.
-*	`LOG_LEVEL`           // Optional - Set the logging level, defaults to Info.
+* `LABELS_FILTER`       // Optional regular expression for filtering service and host labels, defaults to `.*`.
+* `LOG_LEVEL`           // Optional - Set the logging level, defaults to Info.
 
 ## Compatibility
 
@@ -69,7 +69,7 @@ prometheus-rancher-exporter:
       - CATTLE_ACCESS_KEY="xxxx"
       - CATTLE_SECRET_KEY="xxxxxx"
       - CATTLE_URL="http://<YOUR_IP>:8080/v2-beta"
-      - LABELS_FILTER="^service|env|group$"
+      - LABELS_FILTER="^io.prometheus.service|env|group$"
       - HIDE_SYS=true
     expose:
       - 9173:9173

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you are using this externally to Rancher, or without the use of the labels to
 * `METRICS_PATH`        // Path under which to expose metrics.
 * `LISTEN_ADDRESS`      // Port on which to expose metrics.
 * `HIDE_SYS`            // If set to `true` then this hides any of Ranchers internal system services from being shown. *If used, ensure `false` is encapsulated with quotes e.g. `HIDE_SYS="false"`.
+* `LABELS_FILTER`       // Regular expression for filtering service and host labels
 *	`LOG_LEVEL`           // Optional - Set the logging level, defaults to Info
 
 ## Compatibility
@@ -68,6 +69,7 @@ prometheus-rancher-exporter:
       - CATTLE_ACCESS_KEY="xxxx"
       - CATTLE_SECRET_KEY="xxxxxx"
       - CATTLE_URL="http://<YOUR_IP>:8080/v2-beta"
+      - LABELS_FILTER="^service|env|group$"
       - HIDE_SYS=true
     expose:
       - 9173:9173

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you are using this externally to Rancher, or without the use of the labels to
 * `METRICS_PATH`        // Path under which to expose metrics.
 * `LISTEN_ADDRESS`      // Port on which to expose metrics.
 * `HIDE_SYS`            // If set to `true` then this hides any of Ranchers internal system services from being shown. *If used, ensure `false` is encapsulated with quotes e.g. `HIDE_SYS="false"`.
-* `LABELS_FILTER`       // Optional regular expression for filtering service and host labels, defaults to `.*`.
+* `LABELS_FILTER`       // Optional regular expression for filtering service and host labels, defaults to `^io.prometheus`.
 * `LOG_LEVEL`           // Optional - Set the logging level, defaults to Info.
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ If you are using this externally to Rancher, or without the use of the labels to
 * `METRICS_PATH`        // Path under which to expose metrics.
 * `LISTEN_ADDRESS`      // Port on which to expose metrics.
 * `HIDE_SYS`            // If set to `true` then this hides any of Ranchers internal system services from being shown. *If used, ensure `false` is encapsulated with quotes e.g. `HIDE_SYS="false"`.
-* `LABELS_FILTER`       // Regular expression for filtering service and host labels
-*	`LOG_LEVEL`           // Optional - Set the logging level, defaults to Info
+* `LABELS_FILTER`       // Regular expression for filtering service and host labels, defaults to `.*`.
+*	`LOG_LEVEL`           // Optional - Set the logging level, defaults to Info.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ prometheus-rancher-exporter:
       - CATTLE_ACCESS_KEY="xxxx"
       - CATTLE_SECRET_KEY="xxxxxx"
       - CATTLE_URL="http://<YOUR_IP>:8080/v2-beta"
-      - LABELS_FILTER="^io.prometheus.service|env|group$"
       - HIDE_SYS=true
     expose:
       - 9173:9173

--- a/exporter.go
+++ b/exporter.go
@@ -18,7 +18,6 @@ type Exporter struct {
 
 // NewExporter creates the metrics we wish to monitor
 func newExporter(rancherURL string, accessKey string, secretKey string, hideSys bool) *Exporter {
-
 	gaugeVecs := addMetrics()
 	return &Exporter{
 		gaugeVecs:  gaugeVecs,

--- a/exporter.go
+++ b/exporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -8,22 +9,24 @@ import (
 
 // Exporter Sets up all the runtime and metrics
 type Exporter struct {
-	rancherURL string
-	accessKey  string
-	secretKey  string
-	hideSys    bool
-	mutex      sync.RWMutex
-	gaugeVecs  map[string]*prometheus.GaugeVec
+	labelsFilter *regexp.Regexp
+	rancherURL   string
+	accessKey    string
+	secretKey    string
+	hideSys      bool
+	mutex        sync.RWMutex
+	gaugeVecs    map[string]*prometheus.GaugeVec
 }
 
 // NewExporter creates the metrics we wish to monitor
-func newExporter(rancherURL string, accessKey string, secretKey string, hideSys bool) *Exporter {
+func newExporter(rancherURL, accessKey, secretKey string, labelsFilter *regexp.Regexp, hideSys bool) *Exporter {
 	gaugeVecs := addMetrics()
 	return &Exporter{
-		gaugeVecs:  gaugeVecs,
-		rancherURL: rancherURL,
-		accessKey:  accessKey,
-		secretKey:  secretKey,
-		hideSys:    hideSys,
+		labelsFilter: labelsFilter,
+		gaugeVecs:    gaugeVecs,
+		rancherURL:   rancherURL,
+		accessKey:    accessKey,
+		secretKey:    secretKey,
+		hideSys:      hideSys,
 	}
 }

--- a/gather.go
+++ b/gather.go
@@ -49,7 +49,7 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 			continue
 		}
 
-		log.Debug("Processing metrics for %s", endpoint)
+		log.Debugf("Processing metrics for %s", endpoint)
 
 		if endpoint == "hosts" {
 			var s = x.HostName
@@ -142,10 +142,10 @@ func getJSON(url string, accessKey string, secretKey string, target interface{})
 		log.Error("Error Collecting JSON from API: ", err)
 	}
 
-	if ! strings.Contains(resp.Status, "200") {
-		log.Error("Error returned from API: ",resp.Status) 	
-	}	
-	
+	if !strings.Contains(resp.Status, "200") {
+		log.Error("Error returned from API: ", resp.Status)
+	}
+
 	respFormatted := json.NewDecoder(resp.Body).Decode(target)
 
 	// Timings recorded as part of internal metrics
@@ -165,7 +165,7 @@ func setEndpoint(rancherURL string, component string) string {
 	var endpoint string
 
 	endpoint = (rancherURL + "/" + component + "/")
-    endpoint = strings.Replace(endpoint, "v1", "v2-beta", 1)
+	endpoint = strings.Replace(endpoint, "v1", "v2-beta", 1)
 
 	return endpoint
 }

--- a/gather.go
+++ b/gather.go
@@ -113,7 +113,7 @@ func (e *Exporter) gatherData(rancherURL string, accessKey string, secretKey str
 		log.Error("Error getting JSON from endpoint ", endpoint)
 		return nil, err
 	}
-	log.Debugf("JSON Fetched for: "+endpoint+": ", data)
+	log.Debugf("JSON Fetched for: "+endpoint+": %+v", data)
 
 	return data, err
 }

--- a/gather.go
+++ b/gather.go
@@ -14,18 +14,19 @@ import (
 // Data is used to store data from all the relevant endpoints in the API
 type Data struct {
 	Data []struct {
-		HealthState string `json:"healthState"`
-		Name        string `json:"name"`
-		State       string `json:"state"`
-		System      bool   `json:"system"`
-		Scale       int    `json:"scale"`
-		HostName    string `json:"hostname"`
-		ID          string `json:"id"`
-		StackID     string `json:"stackId"`
-		EnvID       string `json:"environmentId"`
-		BaseType    string `json:"basetype"`
-		Type        string `json:"type"`
-		AgentState  string `json:"agentState"`
+		HealthState string            `json:"healthState"`
+		Name        string            `json:"name"`
+		State       string            `json:"state"`
+		System      bool              `json:"system"`
+		Scale       int               `json:"scale"`
+		HostName    string            `json:"hostname"`
+		ID          string            `json:"id"`
+		StackID     string            `json:"stackId"`
+		EnvID       string            `json:"environmentId"`
+		BaseType    string            `json:"basetype"`
+		Type        string            `json:"type"`
+		AgentState  string            `json:"agentState"`
+		Labels      map[string]string `json:"labels"`
 	} `json:"data"`
 }
 

--- a/gather.go
+++ b/gather.go
@@ -27,15 +27,21 @@ type Data struct {
 		Type        string            `json:"type"`
 		AgentState  string            `json:"agentState"`
 		Labels      map[string]string `json:"labels"`
+		// LaunchConfig for services
+		LaunchConfig *LaunchConfig `json:"launchConfig"`
 	} `json:"data"`
+}
+
+type LaunchConfig struct {
+	Labels map[string]string `json:"labels"`
 }
 
 // processMetrics - Collects the data from the API, returns data object
 func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch chan<- prometheus.Metric) error {
+	var filteredLabels map[string]string
 
 	// Metrics - range through the data object
 	for _, x := range data.Data {
-
 		// If system services have been ignored, the loop simply skips them
 		if hideSys == true && x.System == true {
 			continue
@@ -53,19 +59,17 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 		log.Debugf("Processing metrics for %s", endpoint)
 
 		if endpoint == "hosts" {
+			filteredLabels = e.allowedLabels(x.Labels)
 			var s = x.HostName
 			if x.Name != "" {
 				s = x.Name
 			}
-			if err := e.setHostMetrics(s, x.State, x.AgentState); err != nil {
+			if err := e.setHostMetrics(s, x.State, x.AgentState, filteredLabels); err != nil {
 				log.Errorf("Error processing host metrics: %s", err)
 				log.Errorf("Attempt Failed to set %s, %s, [agent] %s ", x.HostName, x.State, x.AgentState)
-
 				continue
 			}
-
 		} else if endpoint == "stacks" {
-
 			// Used to create a map of stackID and stackName
 			// Later used as a dimension in service metrics
 			stackRef = storeStackRef(x.ID, x.Name)
@@ -75,9 +79,7 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 				log.Errorf("Attempt Failed to set %s, %s, %s, %t", x.Name, x.State, x.HealthState, x.System)
 				continue
 			}
-
 		} else if endpoint == "services" {
-
 			// Retrieves the stack Name from the previous values stored.
 			var stackName = retrieveStackRef(x.StackID)
 
@@ -85,15 +87,18 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 				log.Warnf("Failed to obtain stack_name for %s from the API", x.Name)
 			}
 
-			if err := e.setServiceMetrics(x.Name, stackName, x.State, x.HealthState, x.Scale); err != nil {
+			if x.LaunchConfig != nil && len(x.LaunchConfig.Labels) > 0 {
+				filteredLabels = e.allowedLabels(x.LaunchConfig.Labels)
+			}
+
+			if err := e.setServiceMetrics(x.Name, stackName, x.State, x.HealthState, x.Scale, filteredLabels); err != nil {
 				log.Errorf("Error processing service metrics: %s", err)
 				log.Errorf("Attempt Failed to set %s, %s, %s, %s, %d", x.Name, stackName, x.State, x.HealthState, x.Scale)
 				continue
 			}
 
-			e.setServiceMetrics(x.Name, stackName, x.State, x.HealthState, x.Scale)
+			e.setServiceMetrics(x.Name, stackName, x.State, x.HealthState, x.Scale, filteredLabels)
 		}
-
 	}
 
 	return nil
@@ -101,7 +106,6 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 
 // gatherData - Collects the data from thw API, invokes functions to transform that data into metrics
 func (e *Exporter) gatherData(rancherURL string, accessKey string, secretKey string, endpoint string, ch chan<- prometheus.Metric) (*Data, error) {
-
 	// Return the correct URL path
 	url := setEndpoint(rancherURL, endpoint)
 
@@ -119,9 +123,18 @@ func (e *Exporter) gatherData(rancherURL string, accessKey string, secretKey str
 	return data, err
 }
 
+func (e *Exporter) allowedLabels(labels map[string]string) map[string]string {
+	result := make(map[string]string)
+	for name, val := range labels {
+		if e.labelsFilter.MatchString(name) {
+			result[name] = val
+		}
+	}
+	return result
+}
+
 // getJSON return json from server, return the formatted JSON
 func getJSON(url string, accessKey string, secretKey string, target interface{}) error {
-
 	start := time.Now()
 
 	// Counter for internal exporter metrics
@@ -162,7 +175,6 @@ func getJSON(url string, accessKey string, secretKey string, target interface{})
 
 // setEndpoint - Determines the correct URL endpoint to use, gives us backwards compatibility
 func setEndpoint(rancherURL string, component string) string {
-
 	var endpoint string
 
 	endpoint = (rancherURL + "/" + component + "/")
@@ -173,7 +185,6 @@ func setEndpoint(rancherURL string, component string) string {
 
 // storeStackRef stores the stackID and stack name for use as a label elsewhere
 func storeStackRef(stackID string, stackName string) map[string]string {
-
 	stackRef[stackID] = stackName
 
 	return stackRef
@@ -181,7 +192,6 @@ func storeStackRef(stackID string, stackName string) map[string]string {
 
 // retrieveStackRef returns the stack name, when sending the stackID
 func retrieveStackRef(stackID string) string {
-
 	for key, value := range stackRef {
 		if stackID == "" {
 			return "unknown"

--- a/metrics.go
+++ b/metrics.go
@@ -42,7 +42,7 @@ func addMetrics() map[string]*prometheus.GaugeVec {
 			Namespace: namespace,
 			Name:      "service_scale",
 			Help:      "scale of defined service as reported by Rancher",
-		}, []string{"name", "stack_name"})
+		}, []string{"name", "stack_name", "labels"})
 	gaugeVecs["servicesHealth"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
@@ -93,7 +93,11 @@ func checkMetric(endpoint string, baseType string) bool {
 // setServiceMetrics - Logic to set the state of a system as a gauge metric
 func (e *Exporter) setServiceMetrics(name string, stack string, state string, health string, scale int, labels map[string]string) error {
 	labelsStr := joinLabels(labels)
-	e.gaugeVecs["servicesScale"].With(prometheus.Labels{"name": name, "stack_name": stack}).Set(float64(scale))
+	e.gaugeVecs["servicesScale"].With(prometheus.Labels{
+		"name":       name,
+		"stack_name": stack,
+		"labels":     labelsStr,
+	}).Set(float64(scale))
 	for _, y := range healthStates {
 		gauge := e.gaugeVecs["servicesHealth"].With(prometheus.Labels{
 			"name":         name,

--- a/metrics.go
+++ b/metrics.go
@@ -1,10 +1,22 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+func joinLabels(labels map[string]string) string {
+	var result string
+	for name, val := range labels {
+		result += fmt.Sprintf(",%s=%s", name, val)
+	}
+	if len(result) > 0 {
+		result += ","
+	}
+	return result
+}
 
 // addMetrics - Add's all of the GuageVecs to the `guageVecs` map, returns the map.
 func addMetrics() map[string]*prometheus.GaugeVec {
@@ -13,13 +25,13 @@ func addMetrics() map[string]*prometheus.GaugeVec {
 	// Stack Metrics
 	gaugeVecs["stacksHealth"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "rancher",
+			Namespace: namespace,
 			Name:      "stack_health_status",
 			Help:      "HealthState of defined stack as reported by Rancher",
 		}, []string{"name", "health_state", "system"})
 	gaugeVecs["stacksState"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "rancher",
+			Namespace: namespace,
 			Name:      "stack_state",
 			Help:      "State of defined stack as reported by Rancher",
 		}, []string{"name", "state", "system"})
@@ -27,36 +39,36 @@ func addMetrics() map[string]*prometheus.GaugeVec {
 	// Service Metrics
 	gaugeVecs["servicesScale"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "rancher",
+			Namespace: namespace,
 			Name:      "service_scale",
 			Help:      "scale of defined service as reported by Rancher",
 		}, []string{"name", "stack_name"})
 	gaugeVecs["servicesHealth"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "rancher",
+			Namespace: namespace,
 			Name:      "service_health_status",
 			Help:      "HealthState of the service, as reported by the Rancher API. Either (1) or (0)",
-		}, []string{"name", "stack_name", "health_state"})
+		}, []string{"name", "stack_name", "health_state", "labels"})
 	gaugeVecs["servicesState"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "rancher",
+			Namespace: namespace,
 			Name:      "service_state",
 			Help:      "State of the service, as reported by the Rancher API",
-		}, []string{"name", "stack_name", "state"})
+		}, []string{"name", "stack_name", "state", "labels"})
 
 	// Host Metrics
 	gaugeVecs["hostsState"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "rancher",
+			Namespace: namespace,
 			Name:      ("host_state"),
 			Help:      "State of defined host as reported by the Rancher API",
-		}, []string{"name", "state"})
+		}, []string{"name", "state", "labels"})
 	gaugeVecs["hostAgentsState"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "rancher",
+			Namespace: namespace,
 			Name:      ("host_agent_state"),
 			Help:      "State of defined host agent as reported by the Rancher API",
-		}, []string{"name", "state"})
+		}, []string{"name", "state", "labels"})
 
 	return gaugeVecs
 }
@@ -79,24 +91,34 @@ func checkMetric(endpoint string, baseType string) bool {
 }
 
 // setServiceMetrics - Logic to set the state of a system as a gauge metric
-func (e *Exporter) setServiceMetrics(name string, stack string, state string, health string, scale int) error {
+func (e *Exporter) setServiceMetrics(name string, stack string, state string, health string, scale int, labels map[string]string) error {
+	labelsStr := joinLabels(labels)
 	e.gaugeVecs["servicesScale"].With(prometheus.Labels{"name": name, "stack_name": stack}).Set(float64(scale))
-
 	for _, y := range healthStates {
+		gauge := e.gaugeVecs["servicesHealth"].With(prometheus.Labels{
+			"name":         name,
+			"stack_name":   stack,
+			"health_state": y,
+			"labels":       labelsStr,
+		})
 		if health == y {
-			e.gaugeVecs["servicesHealth"].With(prometheus.Labels{"name": name, "stack_name": stack, "health_state": y}).Set(1)
+			gauge.Set(1)
 		} else {
-			e.gaugeVecs["servicesHealth"].With(prometheus.Labels{"name": name, "stack_name": stack, "health_state": y}).Set(0)
+			gauge.Set(0)
 		}
 	}
-
 	for _, y := range serviceStates {
+		gauge := e.gaugeVecs["servicesState"].With(prometheus.Labels{
+			"name":       name,
+			"stack_name": stack,
+			"state":      y,
+			"labels":     labelsStr,
+		})
 		if state == y {
-			e.gaugeVecs["servicesState"].With(prometheus.Labels{"name": name, "stack_name": stack, "state": y}).Set(1)
+			gauge.Set(1)
 		} else {
-			e.gaugeVecs["servicesState"].With(prometheus.Labels{"name": name, "stack_name": stack, "state": y}).Set(0)
+			gauge.Set(0)
 		}
-
 	}
 	return nil
 }
@@ -104,40 +126,58 @@ func (e *Exporter) setServiceMetrics(name string, stack string, state string, he
 // setStackMetrics - Logic to set the state of a system as a gauge metric
 func (e *Exporter) setStackMetrics(name string, state string, health string, system string) error {
 	for _, y := range healthStates {
+		gauge := e.gaugeVecs["stacksHealth"].With(prometheus.Labels{
+			"name":         name,
+			"health_state": y,
+			"system":       system,
+		})
 		if health == y {
-			e.gaugeVecs["stacksHealth"].With(prometheus.Labels{"name": name, "health_state": y, "system": system}).Set(1)
+			gauge.Set(1)
 		} else {
-			e.gaugeVecs["stacksHealth"].With(prometheus.Labels{"name": name, "health_state": y, "system": system}).Set(0)
+			gauge.Set(0)
 		}
 	}
 	for _, y := range stackStates {
+		gauge := e.gaugeVecs["stacksState"].With(prometheus.Labels{
+			"name":   name,
+			"state":  y,
+			"system": system,
+		})
 		if state == y {
-			e.gaugeVecs["stacksState"].With(prometheus.Labels{"name": name, "state": y, "system": system}).Set(1)
+			gauge.Set(1)
 		} else {
-			e.gaugeVecs["stacksState"].With(prometheus.Labels{"name": name, "state": y, "system": system}).Set(0)
+			gauge.Set(0)
 		}
-
 	}
 	return nil
 }
 
 // setHostMetrics - Logic to set the state of a system as a gauge metric
-func (e *Exporter) setHostMetrics(name string, state, agentState string) error {
+func (e *Exporter) setHostMetrics(name string, state, agentState string, labels map[string]string) error {
+	labelsStr := joinLabels(labels)
 	for _, y := range hostStates {
+		gauge := e.gaugeVecs["hostsState"].With(prometheus.Labels{
+			"name":   name,
+			"state":  y,
+			"labels": labelsStr,
+		})
 		if state == y {
-			e.gaugeVecs["hostsState"].With(prometheus.Labels{"name": name, "state": y}).Set(1)
+			gauge.Set(1)
 		} else {
-			e.gaugeVecs["hostsState"].With(prometheus.Labels{"name": name, "state": y}).Set(0)
+			gauge.Set(0)
 		}
-
 	}
 	for _, y := range agentStates {
+		gauge := e.gaugeVecs["hostAgentsState"].With(prometheus.Labels{
+			"name":   name,
+			"state":  y,
+			"labels": labelsStr,
+		})
 		if agentState == y {
-			e.gaugeVecs["hostAgentsState"].With(prometheus.Labels{"name": name, "state": y}).Set(1)
+			gauge.Set(1)
 		} else {
-			e.gaugeVecs["hostAgentsState"].With(prometheus.Labels{"name": name, "state": y}).Set(0)
+			gauge.Set(0)
 		}
-
 	}
 	return nil
 }

--- a/metrics.go
+++ b/metrics.go
@@ -8,7 +8,6 @@ import (
 
 // addMetrics - Add's all of the GuageVecs to the `guageVecs` map, returns the map.
 func addMetrics() map[string]*prometheus.GaugeVec {
-
 	gaugeVecs := make(map[string]*prometheus.GaugeVec)
 
 	// Stack Metrics
@@ -64,7 +63,6 @@ func addMetrics() map[string]*prometheus.GaugeVec {
 
 // checkMetric - Checks the base type stored in the API is correct, this ensures we are setting the right metric for the right endpoint.
 func checkMetric(endpoint string, baseType string) bool {
-
 	e := strings.TrimSuffix(endpoint, "s")
 
 	// Backwards compatibility fix, the API in V1 wrong, this is to cover v1 usage.
@@ -78,12 +76,10 @@ func checkMetric(endpoint string, baseType string) bool {
 	}
 
 	return true
-
 }
 
 // setServiceMetrics - Logic to set the state of a system as a gauge metric
 func (e *Exporter) setServiceMetrics(name string, stack string, state string, health string, scale int) error {
-
 	e.gaugeVecs["servicesScale"].With(prometheus.Labels{"name": name, "stack_name": stack}).Set(float64(scale))
 
 	for _, y := range healthStates {
@@ -103,7 +99,6 @@ func (e *Exporter) setServiceMetrics(name string, stack string, state string, he
 
 	}
 	return nil
-
 }
 
 // setStackMetrics - Logic to set the state of a system as a gauge metric
@@ -128,7 +123,6 @@ func (e *Exporter) setStackMetrics(name string, state string, health string, sys
 
 // setHostMetrics - Logic to set the state of a system as a gauge metric
 func (e *Exporter) setHostMetrics(name string, state, agentState string) error {
-
 	for _, y := range hostStates {
 		if state == y {
 			e.gaugeVecs["hostsState"].With(prometheus.Labels{"name": name, "state": y}).Set(1)

--- a/metrics.go
+++ b/metrics.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,11 +10,14 @@ import (
 
 func joinLabels(labels map[string]string) string {
 	var result string
+	var labelsArray []string
 	for name, val := range labels {
-		result += fmt.Sprintf(",%s=%s", name, val)
+		labelsArray = append(labelsArray, fmt.Sprintf("%s=%s", name, val))
 	}
-	if len(result) > 0 {
-		result += ","
+	if len(labelsArray) > 0 {
+		// Sort for same order
+		sort.Strings(labelsArray)
+		result = fmt.Sprintf(",%s,", strings.Join(labelsArray, ","))
 	}
 	return result
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -7,7 +7,6 @@ import (
 // Resets the guageVecs back to 0
 // Ensures we start from a clean sheet
 func (e *Exporter) resetGaugeVecs() {
-
 	for _, m := range e.gaugeVecs {
 		m.Reset()
 	}
@@ -15,7 +14,6 @@ func (e *Exporter) resetGaugeVecs() {
 
 // Describe describes all the metrics ever exported by the Rancher exporter
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-
 	for _, m := range e.gaugeVecs {
 		m.Describe(ch)
 	}
@@ -23,7 +21,6 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect function, called on by Prometheus Client library
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-
 	e.mutex.Lock() // To protect metrics from concurrent collects.
 	defer e.mutex.Unlock()
 
@@ -50,5 +47,4 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	for _, m := range e.gaugeVecs {
 		m.Collect(ch)
 	}
-
 }

--- a/rancher_exporter.go
+++ b/rancher_exporter.go
@@ -37,7 +37,6 @@ var (
 	healthStates  = []string{"healthy", "unhealthy", "initializing", "degraded", "started-once"}
 	endpoints     = []string{"stacks", "services", "hosts"} // EndPoints the exporter will trawl
 	stackRef      = make(map[string]string)                 // Stores the StackID and StackName as a map, used to provide label dimensions to service metrics
-
 )
 
 // getEnv - Allows us to supply a fallback option if nothing specified
@@ -67,11 +66,11 @@ func main() {
 	measure.Init()
 
 	// Register a new Exporter
-	Exporter := newExporter(rancherURL, accessKey, secretKey, hideSys)
+	exporter := newExporter(rancherURL, accessKey, secretKey, hideSys)
 
 	// Register Metrics from each of the endpoints
 	// This invokes the Collect method through the prometheus client libraries.
-	prometheus.MustRegister(Exporter)
+	prometheus.MustRegister(exporter)
 
 	// Setup HTTP handler
 	http.Handle(metricsPath, prometheus.Handler())

--- a/rancher_exporter.go
+++ b/rancher_exporter.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
@@ -18,12 +19,14 @@ const (
 
 // Runtime variables, user controllable for targeting, authentication and filtering.
 var (
-	metricsPath   = getEnv("METRICS_PATH", "/metrics") // Path under which to expose metrics
-	listenAddress = getEnv("LISTEN_ADDRESS", ":9173")  // Address on which to expose metrics
-	rancherURL    = os.Getenv("CATTLE_URL")            // URL of Rancher Server API e.g. http://192.168.0.1:8080/v2-beta
-	accessKey     = os.Getenv("CATTLE_ACCESS_KEY")     // Optional - Access Key for Rancher API
-	secretKey     = os.Getenv("CATTLE_SECRET_KEY")     // Optional - Secret Key for Rancher API
-	log           = logrus.New()
+	log = logrus.New()
+
+	metricsPath   = getEnv("METRICS_PATH", "/metrics")            // Path under which to expose metrics
+	listenAddress = getEnv("LISTEN_ADDRESS", ":9173")             // Address on which to expose metrics
+	rancherURL    = os.Getenv("CATTLE_URL")                       // URL of Rancher Server API e.g. http://192.168.0.1:8080/v2-beta
+	accessKey     = os.Getenv("CATTLE_ACCESS_KEY")                // Optional - Access Key for Rancher API
+	secretKey     = os.Getenv("CATTLE_SECRET_KEY")                // Optional - Secret Key for Rancher API
+	labelsFilter  = os.Getenv("LABELS_FILTER")                    // Optional - Filter for Rancher label names
 	logLevel      = getEnv("LOG_LEVEL", "info")                   // Optional - Set the logging level
 	hideSys, _    = strconv.ParseBool(getEnv("HIDE_SYS", "true")) // hideSys - Optional - Flag that indicates if the environment variable `HIDE_SYS` is set to a boolean true value
 )
@@ -59,14 +62,32 @@ func main() {
 		log.Fatal("CATTLE_URL must be set and non-empty")
 	}
 
+	if labelsFilter == "" {
+		labelsFilter = ".*"
+	}
+
+	labelsFilterRegexp, err := regexp.Compile(labelsFilter)
+	if err != nil {
+		log.Fatal("LABELS_FILTER must be valid regular expression")
+	}
+
 	log.Info("Starting Prometheus Exporter for Rancher")
-	log.Info("Runtime Configuration in-use: URL of Rancher Server: ", rancherURL, " AccessKey: ", accessKey, "System Services hidden: ", hideSys)
+	log.Info(
+		"Runtime Configuration in-use: URL of Rancher Server: ",
+		rancherURL,
+		" Access key: ",
+		accessKey,
+		" System services hidden: ",
+		hideSys,
+		" Labels filter: ",
+		labelsFilter,
+	)
 
 	// Register internal metrics used for tracking the exporter performance
 	measure.Init()
 
 	// Register a new Exporter
-	exporter := newExporter(rancherURL, accessKey, secretKey, hideSys)
+	exporter := newExporter(rancherURL, accessKey, secretKey, labelsFilterRegexp, hideSys)
 
 	// Register Metrics from each of the endpoints
 	// This invokes the Collect method through the prometheus client libraries.

--- a/rancher_exporter.go
+++ b/rancher_exporter.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	namespace = "rancher" // Used to prepand Prometheus metrics created by this exporter.
+	namespace           = "rancher" // Used to prepand Prometheus metrics created by this exporter.
+	defaultLabelsFilter = "^io.prometheus"
 )
 
 // Runtime variables, user controllable for targeting, authentication and filtering.
@@ -63,7 +64,7 @@ func main() {
 	}
 
 	if labelsFilter == "" {
-		labelsFilter = ".*"
+		labelsFilter = defaultLabelsFilter
 	}
 
 	labelsFilterRegexp, err := regexp.Compile(labelsFilter)


### PR DESCRIPTION
* Labels can be filtered by regexp from environment variable `LABELS_FILTER`, by defaults filter set to `^io.prometheus`, exporter will fail if regexp is not valid;
* All Rancher labels stored in one Prometheus label and comma-separated, very similar to tags from Consul SD (`__meta_consul_tags: ",prod,web,"`) – `labels=",io.prometheus.group=pfa,"`.

Is it looks good or not? Please comment.