### PR TITLE
extend limit option for rancher api

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you are using this externally to Rancher, or without the use of the labels to
 * `HIDE_SYS`            // If set to `true` then this hides any of Ranchers internal system services from being shown. *If used, ensure `false` is encapsulated with quotes e.g. `HIDE_SYS="false"`.
 * `LABELS_FILTER`       // Optional regular expression for filtering service and host labels, defaults to `^io.prometheus`.
 * `LOG_LEVEL`           // Optional - Set the logging level, defaults to Info.
+* `API_LIMIT`           // Optional - Rancher API resource limit (default: 100)
 
 ## Compatibility
 

--- a/exporter.go
+++ b/exporter.go
@@ -9,24 +9,26 @@ import (
 
 // Exporter Sets up all the runtime and metrics
 type Exporter struct {
-	labelsFilter *regexp.Regexp
-	rancherURL   string
-	accessKey    string
-	secretKey    string
-	hideSys      bool
-	mutex        sync.RWMutex
-	gaugeVecs    map[string]*prometheus.GaugeVec
+	labelsFilter  *regexp.Regexp
+	rancherURL    string
+	accessKey     string
+	secretKey     string
+	hideSys       bool
+	resourceLimit string
+	mutex         sync.RWMutex
+	gaugeVecs     map[string]*prometheus.GaugeVec
 }
 
 // NewExporter creates the metrics we wish to monitor
-func newExporter(rancherURL, accessKey, secretKey string, labelsFilter *regexp.Regexp, hideSys bool) *Exporter {
+func newExporter(rancherURL, accessKey, secretKey string, labelsFilter *regexp.Regexp, hideSys bool, resourceLimit string) *Exporter {
 	gaugeVecs := addMetrics()
 	return &Exporter{
-		labelsFilter: labelsFilter,
-		gaugeVecs:    gaugeVecs,
-		rancherURL:   rancherURL,
-		accessKey:    accessKey,
-		secretKey:    secretKey,
-		hideSys:      hideSys,
+		labelsFilter:  labelsFilter,
+		gaugeVecs:     gaugeVecs,
+		rancherURL:    rancherURL,
+		accessKey:     accessKey,
+		secretKey:     secretKey,
+		hideSys:       hideSys,
+		resourceLimit: resourceLimit,
 	}
 }

--- a/gather.go
+++ b/gather.go
@@ -105,9 +105,9 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 }
 
 // gatherData - Collects the data from thw API, invokes functions to transform that data into metrics
-func (e *Exporter) gatherData(rancherURL string, accessKey string, secretKey string, endpoint string, ch chan<- prometheus.Metric) (*Data, error) {
+func (e *Exporter) gatherData(rancherURL string, resourceLimit string, accessKey string, secretKey string, endpoint string, ch chan<- prometheus.Metric) (*Data, error) {
 	// Return the correct URL path
-	url := setEndpoint(rancherURL, endpoint)
+	url := setEndpoint(rancherURL, endpoint, resourceLimit)
 
 	// Create new data slice from Struct
 	var data = new(Data)
@@ -174,10 +174,10 @@ func getJSON(url string, accessKey string, secretKey string, target interface{})
 }
 
 // setEndpoint - Determines the correct URL endpoint to use, gives us backwards compatibility
-func setEndpoint(rancherURL string, component string) string {
+func setEndpoint(rancherURL string, component string, resourceLimit string) string {
 	var endpoint string
 
-	endpoint = (rancherURL + "/" + component + "/")
+	endpoint = (rancherURL + "/" + component + "/" + "?limit=" + resourceLimit)
 	endpoint = strings.Replace(endpoint, "v1", "v2-beta", 1)
 
 	return endpoint

--- a/prometheus.go
+++ b/prometheus.go
@@ -29,7 +29,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	// Range over the pre-configured endpoints array
 	for _, p := range endpoints {
 
-		var data, err = e.gatherData(e.rancherURL, e.accessKey, e.secretKey, p, ch)
+		var data, err = e.gatherData(e.rancherURL, e.resourceLimit, e.accessKey, e.secretKey, p, ch)
 
 		if err != nil {
 			log.Error("Error getting JSON from URL ", p)

--- a/rancher_exporter.go
+++ b/rancher_exporter.go
@@ -29,6 +29,7 @@ var (
 	secretKey     = os.Getenv("CATTLE_SECRET_KEY")                // Optional - Secret Key for Rancher API
 	labelsFilter  = os.Getenv("LABELS_FILTER")                    // Optional - Filter for Rancher label names
 	logLevel      = getEnv("LOG_LEVEL", "info")                   // Optional - Set the logging level
+	resourceLimit = getEnv("API_LIMIT", "100")                    // Optional - Rancher API resource limit (default: 100)
 	hideSys, _    = strconv.ParseBool(getEnv("HIDE_SYS", "true")) // hideSys - Optional - Flag that indicates if the environment variable `HIDE_SYS` is set to a boolean true value
 )
 
@@ -88,7 +89,7 @@ func main() {
 	measure.Init()
 
 	// Register a new Exporter
-	exporter := newExporter(rancherURL, accessKey, secretKey, labelsFilterRegexp, hideSys)
+	exporter := newExporter(rancherURL, accessKey, secretKey, labelsFilterRegexp, hideSys, resourceLimit)
 
 	// Register Metrics from each of the endpoints
 	// This invokes the Collect method through the prometheus client libraries.


### PR DESCRIPTION
By setting `API_LIMIT` environment variable, change limit of rancher api result.
Currently, there is no option to change default setting. (Default 100)